### PR TITLE
Removed gpg-agent: formuale not available anymore

### DIFF
--- a/setup-script.sh
+++ b/setup-script.sh
@@ -87,7 +87,7 @@ ln -sf "/Users/${USER}/dotfiles/gpg-agent.conf" "/Users/${USER}/.gnupg/gpg-agent
 curl -L https://aka.ms/InstallAzureCli | bash
 
 # install GPG signing for git
-brew install gnupg gpg-agent pinentry-mac
+brew install gnupg pinentry-mac
 
 # setup GPG signing for git from here:
 open https://github.com/pstadler/keybase-gpg-github


### PR DESCRIPTION
If you try to install gpg-agent you get: Error: No available formula with the name "gpg-agent". 

gpg-agent now comes bundled with gnupg so no need to install it separately. 

See https://stackoverflow.com/questions/52435650/gpg-agent-not-found-for-homebrew 
and 
https://github.com/Homebrew/homebrew-core/commit/965e130e04e5900e35bf1f0b6ebad9d1c2f680a7 for more info.